### PR TITLE
fix: Animations and SEO-friendly links now work together

### DIFF
--- a/pages/kommun/[municipality]/[step].tsx
+++ b/pages/kommun/[municipality]/[step].tsx
@@ -14,13 +14,19 @@ export default function Step() {
   const onNext = () => {
     const next = STEPS[stepIndex + 1]
     if (!next) throw new Error(`Assertion failed: No step with index ${stepIndex + 1}`)
-    router.replace(`/kommun/${municipality}/${next}`, undefined, { scroll: false })
+    router.replace(`/kommun/${municipality}/${next}`, undefined, {
+      shallow: true,
+      scroll: false,
+    })
   }
 
   const onPrevious = () => {
     const prev = STEPS[stepIndex - 1]
     if (!prev) throw new Error(`Assertion failed: No step with index ${stepIndex - 1}`)
-    router.replace(`/kommun/${municipality}/${prev}`, undefined, { scroll: false })
+    router.replace(`/kommun/${municipality}/${prev}`, undefined, {
+      shallow: true,
+      scroll: false,
+    })
   }
 
   return (


### PR DESCRIPTION
> Shallow routing allows you to change the URL without running data fetching methods again, that includes [getServerSideProps](https://nextjs.org/docs/basic-features/data-fetching/get-server-side-props), [getStaticProps](https://nextjs.org/docs/basic-features/data-fetching/get-static-props), and [getInitialProps](https://nextjs.org/docs/api-reference/data-fetching/get-initial-props).

https://nextjs.org/docs/routing/shallow-routing

Luckily!